### PR TITLE
Bump firebase/php-jwt dependency to version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "guzzle/guzzle": "~3.9",
         "psr/log": "~1.0",
-        "firebase/php-jwt": "~1.0"
+        "firebase/php-jwt": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"

--- a/src/CareerBuilder/OAuth2/Flows/Flow.php
+++ b/src/CareerBuilder/OAuth2/Flows/Flow.php
@@ -17,7 +17,7 @@ use Guzzle\Http\ClientInterface;
 use Guzzle\Http\Client;
 use Guzzle\Plugin\Log\LogPlugin;
 use Guzzle\Log\PsrLogAdapter;
-use JWT;
+use Firebase\JWT\JWT;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 


### PR DESCRIPTION
Version 1.0 has known vulnerabilities. This makes it likely that projects that already depend on `php-jwt` will require a more recent version resulting in a "dependency hell" situation.