### PR TITLE
updated for CB API standard format for token response

### DIFF
--- a/src/CareerBuilder/OAuth2/Flows/Flow.php
+++ b/src/CareerBuilder/OAuth2/Flows/Flow.php
@@ -132,9 +132,9 @@ abstract class Flow
         $response = $request->send();
         $data = $response->json();
 
-        $refreshToken = isset($data['refresh_token']) ?: '';
+        $refreshToken = isset($data['data']['refresh_token']) ?: '';
 
-        return new AccessToken($data['access_token'], $refreshToken, $data['expires_in']);
+        return new AccessToken($data['data']['access_token'], $refreshToken, $data['data']['expires_in']);
     }
 
     protected abstract function buildBody();

--- a/src/CareerBuilder/OAuth2/Flows/JWTBearerAssertion.php
+++ b/src/CareerBuilder/OAuth2/Flows/JWTBearerAssertion.php
@@ -56,7 +56,7 @@ class JWTBearerAssertion extends Flow
         return array(
             'iss' => $this->clientId,
             'sub' => "{$this->email}:{$this->accountId}",
-            'aud' => 'www.careerbuilder.com/share/oauth2'
+            'aud' => 'www.careerbuilder.com/share/oauth2',
             'exp' => time() + 30
         );
     }


### PR DESCRIPTION
We now use a standard data node and errors array node in the response body. This change is to utilize that body and move away from unnested data.